### PR TITLE
Fix row buffer allocation

### DIFF
--- a/src/java/io/framed/BTableWriter.java
+++ b/src/java/io/framed/BTableWriter.java
@@ -44,7 +44,7 @@ public class BTableWriter {
         // Each row is prefixed for number of materialized values +
         // pessimistically allocated for worst-case dense row
         int ncols = header.split(SEP).length;
-        buf = ByteBuffer.allocate(4 + (8 * ncols));
+        buf = ByteBuffer.allocate(4 + (4 * ncols) + (8 * ncols));
 
         for (Iterable<Object> row : rows) {
             buf.clear();


### PR DESCRIPTION
This was not properly allocating for dense indices (4 byte ints), meaning a
fully-dense row could cause a buffer overflow.
